### PR TITLE
XFIL-3610 mention extension - support rendering within an iframe + project scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ A fork of tiptap with changes necessary for our applications. The goal is to (wh
 Currently this repo has the following changes that are not in upstream:
 - `packages/extension-mention` - [Add support for cross-iframe JS](https://github.com/lassoworkforce/tiptap/commit/cf7f763cb311ce50caa69092ed079bd66adf7da2)
 
+## Making changes and publishing our own versions
+
+While waiting for upstreaming, we use github packages to publish versions with our changes under our `@lassoworkforce` namespace.
+
+1. For the package you want to publish in `packages/`, update its `package.json` (if not already updated) to
+  - Use a name under `@lassoworkforce` e.g. `@lassoworkforce/tiptap-extension-mention`
+  - Append a suffix to the extension version e.g. `2.0.3-lasso-1`
+2. In that packages folder, make any changes you need to make.
+3. Test those changes in the demos build (`npm run start`) and/or in our application using [yalc](https://github.com/wclr/yalc)
+4. Compile the package `npm run build`
+5. Publish the package `npm publish`
+
+-----------------------
+
 # Tiptap
 A headless, framework-agnostic and extendable rich text editor, based on [ProseMirror](https://github.com/ProseMirror/prosemirror).
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ While waiting for upstreaming, we use github packages to publish versions with o
   - Use a name under `@lassoworkforce` e.g. `@lassoworkforce/tiptap-extension-mention`
   - Append a suffix to the extension version e.g. `2.0.3-lasso-1`
 2. In that packages folder, make any changes you need to make.
-3. Test those changes in the demos build (`npm run start`) and/or in our application using [yalc](https://github.com/wclr/yalc)
-4. Compile the package `npm run build`
-5. Publish the package `npm publish`
+3. Test those changes in the demos application (`npm run start` in the repo root) and/or in our application using [yalc](https://github.com/wclr/yalc)
+4. Compile the package `npm run build` (in your package subfolder)
+5. Publish the package `npm publish` (in your package subfolder)
 
 -----------------------
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# lassoworkforce tiptap
+
+A fork of tiptap with changes necessary for our applications. The goal is to (when appropriate) PR changes to upstream and use upstream npm packages whenever possible.
+
+Currently this repo has the following changes that are not in upstream:
+- `packages/extension-mention` - [Add support for cross-iframe JS](https://github.com/lassoworkforce/tiptap/commit/cf7f763cb311ce50caa69092ed079bd66adf7da2)
+
 # Tiptap
 A headless, framework-agnostic and extendable rich text editor, based on [ProseMirror](https://github.com/ProseMirror/prosemirror).
 

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@tiptap/extension-mention",
+  "name": "@lassoworkforce/tiptap-extension-mention",
   "description": "mention extension for tiptap",
-  "version": "2.0.3",
+  "version": "2.0.3-lasso-1",
   "homepage": "https://tiptap.dev",
   "keywords": [
     "tiptap",

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -48,7 +48,8 @@ export const Mention = Node.create<MentionOptions>({
             ])
             .run()
 
-          window.getSelection()?.collapseToEnd()
+          // get reference to `window` object from editor element, to support cross-frame JS usage
+          editor.view.dom.ownerDocument.defaultView?.getSelection()?.collapseToEnd()
         },
         allow: ({ state, range }) => {
           const $from = state.doc.resolve(range.from)


### PR DESCRIPTION
- Support rendering a tiptap editor with a mention extension from within an outer document into a same-origin iframe by using the correct `window` instance
- Add README for our fork
- Prep `package.json` for forked package distribution